### PR TITLE
Update convert.js to fix incorrect handling of some images

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -565,6 +565,7 @@ async function ConvertImageWithOCRAPI(apiKey, outputType, source, destination, h
   process.stdout.cursorTo(0);
 
   let responseJSON = await res.json();
+  if (! ('latex_styled' in responseJSON)) responseJSON['latex_styled'] = responseJSON['text'];
   if (destination.endsWith("docx")) {
     await MarkdownToDocx(responseJSON["latex_styled"], destination, true);
   } else if (destination.endsWith("tex")) {


### PR DESCRIPTION
this script uses the "latex_styled" response field to extract the output. but for some images the "latex_styled" field is not return, only the "text" is returned for such images it fails with the "could not write to destination path" error  (with the incorrect error message).

this commit fixes this by using the "text" field if the "latex_styled" field is not available.

example of the failing image is attached (check with ocr api mode, not with snip mode)
for this image, only the text field is return, latex_styled is not.

![cont2ex](https://github.com/Mathpix/mpx-cli/assets/40538919/952ac18b-1abb-4b04-ae8b-1dbe8ff6ad19)
