### PR TITLE
Treat .md destinations from PDF as vanilla Markdown

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -428,6 +428,10 @@ async function PDFToMMD(source, destination) {
   await ConvertPDF("mmd", source, destination);
 }
 
+async function PDFToVanillaMarkdown(source, destination) {
+  await ConvertPDF("md", source, destination);
+}
+
 async function PDFToDOCX(source, destination) {
   await ConvertPDF("docx", source, destination);
 }
@@ -635,6 +639,7 @@ module.exports = {
   MarkdownToLatexPDF,
   MarkdownToMarkdown,
   PDFToMMD,
+  PDFToVanillaMarkdown,
   PDFToDOCX,
   PDFToTEX,
   PDFToHTML,

--- a/lib/mpx.js
+++ b/lib/mpx.js
@@ -154,8 +154,11 @@ program
       }
 
       switch (true) {
-        case sourceExt === ".pdf" && (destinationExt === ".mmd" || destinationExt === ".md"):
+        case sourceExt === ".pdf" && destinationExt === ".mmd":
           await convert.PDFToMMD(source, destination);
+          break;
+        case sourceExt === ".pdf" && destinationExt === ".md":
+          await convert.PDFToVanillaMarkdown(source, destination);
           break;
         case sourceExt === ".pdf" && destinationExt === ".html":
           await convert.PDFToHTML(source, destination);


### PR DESCRIPTION
This is the code I'm using to generate vanilla `.md` files with this tool (issue #14). I don't know whether this is the best way to implement it -- maybe there should be a command line option instead. I'd find this behavior reasonably intuitive though.

The reason I needed vanilla markdown files is because I'm putting the results into LLM prompts, so I want the Markdown to be easy to read and token-efficient.

I'm noticing that further down in `mpx.js`, converting from `.mmd` to `.md` just results in an `fs.copy`. I'm not sure if there are conversion facilities between `.mmd` and `.md` -- if there are, that code might need adjusting too to for consistency.

I also looked at adding vanilla markdown to the image conversion functions, but the outputType (`"mmd"` here) in calls to `ConvertImage` isn't used in the implementation:

```js
async function ImageToMMD(source, destination) {
  await ConvertImage("mmd", source, destination);
}
```

I probably won't have the bandwidth to update this pull request, so if it's not useful, please feel free to just close, or use it as a starting point.