### PR TITLE
Improve error handling and update OCR API JSON key from "latex_styled" to "text"

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -493,19 +493,31 @@ async function ConvertImageWithSnipAPI(authToken, outputType, source, destinatio
   process.stdout.cursorTo(0);
 
   let responseJSON = await res.json();
+  if (responseJSON.errors !== undefined) {
+    console.error("Error(s) encountered:\n");
+    console.error(responseJSON.errors);
+    return process.exit(1);
+  }
+  let textDisplay = responseJSON["text_display"];
+  if (textDisplay === undefined) {
+    console.error("No LaTeX found in response:\n");
+    console.error(responseJSON);
+    return process.exit(1);
+  }
+
   if (destination.endsWith("docx")) {
-    await MarkdownToDocx(responseJSON["text_display"], destination, true);
+    await MarkdownToDocx(textDisplay, destination, true);
   } else if (destination.endsWith("tex")) {
-    await MarkdownToTex(responseJSON["text_display"], destination, true);
+    await MarkdownToTex(textDisplay, destination, true);
   } else if (destination.endsWith("pdf") && htmlPDF) {
-    await MarkdownToHTMLPDF(responseJSON["text_display"], destination, true);
+    await MarkdownToHTMLPDF(textDisplay, destination, true);
   } else if (destination.endsWith("pdf")) {
-    await MarkdownToLatexPDF(responseJSON["text_display"], destination, true);
+    await MarkdownToLatexPDF(textDisplay, destination, true);
   } else if (destination.endsWith("html")) {
-    await MarkdownToHTML(responseJSON["text_display"], destination, true);
+    await MarkdownToHTML(textDisplay, destination, true);
   } else {
     try {
-      fs.writeFileSync(destination, responseJSON["text_display"]);
+      fs.writeFileSync(destination, textDisplay);
     } catch (err) {
       console.log(`Could not write to destination path: ${destination}`);
       return process.exit(1);
@@ -565,19 +577,25 @@ async function ConvertImageWithOCRAPI(apiKey, outputType, source, destination, h
   process.stdout.cursorTo(0);
 
   let responseJSON = await res.json();
+  let latex = responseJSON["text"];
+  if (latex === undefined) {
+    console.error("No LaTeX found in response:\n");
+    console.error(responseJSON);
+    return process.exit(1);
+  }
   if (destination.endsWith("docx")) {
-    await MarkdownToDocx(responseJSON["latex_styled"], destination, true);
+    await MarkdownToDocx(latex, destination, true);
   } else if (destination.endsWith("tex")) {
-    await MarkdownToTex(responseJSON["latex_styled"], destination, true);
+    await MarkdownToTex(latex, destination, true);
   } else if (destination.endsWith("pdf") && htmlPDF) {
-    await MarkdownToHTMLPDF(responseJSON["latex_styled"], destination, true);
+    await MarkdownToHTMLPDF(latex, destination, true);
   } else if (destination.endsWith("pdf")) {
-    await MarkdownToLatexPDF(responseJSON["latex_styled"], destination, true);
+    await MarkdownToLatexPDF(latex, destination, true);
   } else if (destination.endsWith("html")) {
-    await MarkdownToHTML(responseJSON["latex_styled"], destination, true);
+    await MarkdownToHTML(latex, destination, true);
   } else {
     try {
-      fs.writeFileSync(destination, responseJSON["latex_styled"]);
+      fs.writeFileSync(destination, latex);
     } catch (err) {
       console.log(`Could not write to destination path: ${destination}`);
       return process.exit(1);


### PR DESCRIPTION
This code in `convert.js`

```
    try {
      fs.writeFileSync(destination, responseJSON["text_display"]);
    } catch (err) {
      console.log(`Could not write to destination path: ${destination}`);
      return process.exit(1);
    }
```

just prints "Could not write to destination path" when the `"text_display"` key is missing. This PR improves the error handling and updates the JSON key.

This is a bug report more so than a PR -- I won't have the bandwidth to update this PR, but feel free to use it as a starting point.